### PR TITLE
Add ClientChecks and other missing statuses.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -31,7 +31,8 @@ class Lambda {
     clientFilePath <- processor.clientFilePath()
     redactedStatus <- processor.redactedStatus()
     serverFFID <- processor.serverFFID()
-  } yield ffid ::: av ::: checksumMatch ::: serverChecksum ::: clientChecksum ::: clientFilePath ::: redactedStatus ::: serverFFID
+    clientChecks <- processor.clientChecks()
+  } yield ffid ::: av ::: checksumMatch ::: serverChecksum ::: clientChecksum ::: clientFilePath ::: redactedStatus ::: serverFFID ::: clientChecks
 
   def run(inputStream: InputStream, outputStream: OutputStream): Unit = {
     val inputString = Source.fromInputStream(inputStream).mkString

--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -31,11 +31,12 @@ class Lambda {
     clientFilePath <- processor.clientFilePath()
     redactedStatus <- processor.redactedStatus()
     serverFFID <- processor.serverFFID()
+    serverAV <- processor.serverAntivirus()
     fileClientChecks <- processor.fileClientChecks()
     consignmentClientChecks <- processor.consignmentClientChecks()
   } yield ffid ::: av ::: checksumMatch ::: serverChecksum ::: clientChecksum :::
     clientFilePath ::: redactedStatus ::: serverFFID ::: fileClientChecks :::
-    consignmentClientChecks
+    consignmentClientChecks ::: serverAV
 
   def run(inputStream: InputStream, outputStream: OutputStream): Unit = {
     val inputString = Source.fromInputStream(inputStream).mkString

--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -31,8 +31,11 @@ class Lambda {
     clientFilePath <- processor.clientFilePath()
     redactedStatus <- processor.redactedStatus()
     serverFFID <- processor.serverFFID()
-    clientChecks <- processor.clientChecks()
-  } yield ffid ::: av ::: checksumMatch ::: serverChecksum ::: clientChecksum ::: clientFilePath ::: redactedStatus ::: serverFFID ::: clientChecks
+    fileClientChecks <- processor.fileClientChecks()
+    consignmentClientChecks <- processor.consignmentClientChecks()
+  } yield ffid ::: av ::: checksumMatch ::: serverChecksum ::: clientChecksum :::
+    clientFilePath ::: redactedStatus ::: serverFFID ::: fileClientChecks :::
+    consignmentClientChecks
 
   def run(inputStream: InputStream, outputStream: OutputStream): Unit = {
     val inputString = Source.fromInputStream(inputStream).mkString

--- a/src/main/scala/uk/gov/nationalarchives/StatusProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/StatusProcessor.scala
@@ -18,6 +18,7 @@ class StatusProcessor[F[_] : Monad](input: Input, allPuidInformation: AllPuidInf
   private val ConsignmentType = "Consignment"
   private val Failed = "Failed"
   private val ServerChecksum = "ServerChecksum"
+  private val ServerAntivirus = "ServerAntivirus"
   private val ZeroByteFile = "ZeroByteFile"
   private val ClientChecksum = "ClientChecksum"
   private val ClientFilePath = "ClientFilePath"
@@ -76,8 +77,29 @@ class StatusProcessor[F[_] : Monad](input: Input, allPuidInformation: AllPuidInf
     }).pure[F]
   }
 
-  def serverChecksum(): F[List[Status]] =
-    statusIfEmpty(res => res.fileCheckResults.checksum.map(_.sha256Checksum).headOption, ServerChecksum)
+  def serverChecksum(): F[List[Status]] = {
+    for {
+      consignmentStatus <- clientChecksum().map(cc => {
+        val value = if (cc.exists(_.statusValue != Success)) {
+          CompletedWithIssues
+        } else {
+          Completed
+        }
+        Status(input.results.head.consignmentId, ConsignmentType, ServerChecksum, value, overwrite = true) :: Nil
+      })
+      fileStatuses <-  statusIfEmpty(res => res.fileCheckResults.checksum.map(_.sha256Checksum).headOption, ServerChecksum)
+    } yield consignmentStatus ++ fileStatuses
+
+  }
+
+  def serverAntivirus(): F[List[Status]] = antivirus().map(av => {
+    val value = if (av.exists(_.statusValue != Success)) {
+      CompletedWithIssues
+    } else {
+      Completed
+    }
+    Status(input.results.head.consignmentId, ConsignmentType, ServerAntivirus, value, overwrite = true) :: Nil
+  })
 
   def clientChecksum(): F[List[Status]] = statusIfEmpty(res => res.clientChecksum.some, ClientChecksum)
 

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -21,7 +21,7 @@ class LambdaTest extends TestUtils {
     val replacementsMap = Map("Antivirus" -> "", "ClientChecksum" -> "abc", "ServerChecksum" -> "abc", "FileSize" -> "1")
     val statuses: List[Status] = getStatuses(replacementsMap, container)
 
-    statuses.size should equal(8)
+    statuses.size should equal(9)
 
     def filterStatus(name: String): List[String] = statuses.filter(_.statusName == name).map(_.statusValue)
 

--- a/src/test/scala/uk/gov/nationalarchives/TestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/TestUtils.scala
@@ -19,6 +19,7 @@ import scala.io.Source
 
 class TestUtils extends AnyFlatSpec with TableDrivenPropertyChecks with MockitoSugar with TestContainerForAll {
   val Success = "Success"
+  val Completed = "Completed"
   val Failed = "Failed"
 
   override val containerDef: ContainerDef = PostgreSQLContainer.Def(
@@ -57,8 +58,8 @@ class TestUtils extends AnyFlatSpec with TableDrivenPropertyChecks with MockitoS
     decode[StatusResult](output).getOrElse(StatusResult(Nil)).statuses
   }
 
-  def getStatus(inputReplacements: Map[String, String], container: PostgreSQLContainer, statusName: String): String = {
+  def getStatus(inputReplacements: Map[String, String], container: PostgreSQLContainer, statusName: String, statusType: String): String = {
     val statuses = getStatuses(inputReplacements, container)
-    statuses.filter(_.statusName == statusName).map(_.statusValue).head
+    statuses.filter(s => s.statusName == statusName && s.statusType == statusType).map(_.statusValue).head
   }
 }


### PR DESCRIPTION
There is a status which is added in the API called ClientChecks which returns CompletedWithIssues if the file size is zero or the checksum or path are missing. I've added this in here so it can be removed from the API.
There is also a consignment status which is set to Completed or CompletedWithIssues depending on the individual file statuses and I've added these in here as well.
I've also added in ServerAntivirus and the consignment level ServerChecksum which were also missing.
