### PR TITLE
Ovewrite existing statuses and read from S3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,8 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
       awsRds,
       awsSsm,
+      awsS3,
+      backendCheckUtils,
       circeCore,
       circeParser,
       circeGeneric,
@@ -20,7 +22,8 @@ lazy val root = (project in file("."))
       mockito % Test,
       scalaTest % Test,
       testContainersScala % Test,
-      testContainersPostgres % Test
+      testContainersPostgres % Test,
+      wiremock % Test
     ),
     assembly / assemblyJarName := "statuses.jar"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -35,4 +35,6 @@ lazy val root = (project in file("."))
 
 Test / fork := true
 Test / javaOptions += s"-Dconfig.file=${sourceDirectory.value}/test/resources/application.conf"
-Test / envVars := Map("AWS_ACCESS_KEY_ID" -> "test", "AWS_SECRET_ACCESS_KEY" -> "test", "AWS_REGION" -> "eu-west-2")
+(Test / fork) := true
+(Test / javaOptions) += s"-Dconfig.file=${sourceDirectory.value}/test/resources/application.conf"
+(Test / envVars) := Map("AWS_ACCESS_KEY_ID" -> "test", "AWS_SECRET_ACCESS_KEY" -> "test", "S3_ENDPOINT" -> "http://localhost:9005")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,11 +3,13 @@ import sbt._
 object Dependencies {
   private val circeVersion = "0.14.3"
   private val testContainersVersion = "0.40.11"
-  private val awsVersion = "2.18.24"
+  private val awsVersion = "2.19.21"
   private val doobieVersion = "1.0.0-RC1"
 
   lazy val awsRds = "software.amazon.awssdk" % "rds" % awsVersion
   lazy val awsSsm = "software.amazon.awssdk" % "ssm" % awsVersion
+  lazy val awsS3 = "software.amazon.awssdk" % "s3" % awsVersion
+  lazy val backendCheckUtils = "uk.gov.nationalarchives" %% "tdr-backend-checks-utils" % "0.1.0"
   lazy val circeCore = "io.circe" %% "circe-core" % circeVersion
   lazy val circeParser = "io.circe" %% "circe-parser" % circeVersion
   lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
@@ -15,9 +17,10 @@ object Dependencies {
   lazy val pureConfig = "com.github.pureconfig" %% "pureconfig" % "0.17.2"
   lazy val doobie = "org.tpolecat" %% "doobie-core" % doobieVersion
   lazy val doobiePostgres = "org.tpolecat" %% "doobie-postgres"  % doobieVersion
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.14"
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.15"
   lazy val catsTesting = "org.typelevel" %% "cats-effect-testing-scalatest" % "1.4.0"
   lazy val testContainersScala = "com.dimafeng" %% "testcontainers-scala-scalatest" % testContainersVersion
   lazy val testContainersPostgres = "com.dimafeng" %% "testcontainers-scala-postgresql" % testContainersVersion
   lazy val mockito = "org.mockito" %% "mockito-scala" % "1.17.12"
+  lazy val wiremock = "com.github.tomakehurst" % "wiremock-jre8" % "2.35.0"
 }

--- a/src/main/scala/uk/gov/nationalarchives/LambdaRunner.scala
+++ b/src/main/scala/uk/gov/nationalarchives/LambdaRunner.scala
@@ -5,54 +5,8 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 object LambdaRunner extends App {
   private val body =
     """{
-      |  "results": [
-      |    {
-      |      "consignmentId": "68c11ad6-f7e2-4506-833a-a28426aecbdd",
-      |      "fileId": "20d80488-d247-47cf-8687-be26de2558b5",
-      |      "originalPath": "smallfile/subfolder/subfolder-nested/subfolder-nested-1.txt",
-      |      "fileSize": "2",
-      |      "clientChecksum": "87428fc522803d31065e7bce3cf03fe475096631e5e07bbd7a0fde60c4cf25c7",
-      |      "consignmentType": "standard",
-      |      "fileCheckResults": {
-      |        "antivirus": [
-      |          {
-      |            "result": "",
-      |            "fileId": "20d80488-d247-47cf-8687-be26de2558b5"
-      |          }
-      |        ],
-      |        "checksum": [
-      |          {
-      |            "sha256Checksum": "87428fc522803d31065e7bce3cf03fe475096631e5e07bbd7a0fde60c4cf25c7"
-      |          }
-      |        ],
-      |        "fileFormat": [
-      |          {
-      |            "matches": [
-      |              {
-      |                "puid": "fmt/866"
-      |              }
-      |            ]
-      |          }
-      |        ]
-      |      }
-      |    }
-      |  ],
-      |  "redactedResults": {
-      |    "redactedFiles": [
-      |      {
-      |        "originalFileId": "4dbabaef-1fae-4d09-8faa-88e9dfb85b05",
-      |        "originalFilePath": "originalPath",
-      |        "redactedFileId": "7daa4ab6-ab7d-449a-88f5-a8ff1705b888",
-      |        "redactedFilePath": "redactedPath"
-      |      }
-      |    ],
-      |    "errors": [
-      |      {
-      |        "fileId": "97536958-2192-4485-af9a-d98a0290e692",
-      |        "cause": "TestFailureReason"
-      |      }
-      |    ]
-      |  }
+      |  "key": "a4c0e084-7562-46dd-9724-92ac9b64d149/d5cd3fb2-4869-4d28-9537-4655486a8a2d/results.json",
+      |  "bucket": "tdr-backend-checks-intg"
       |}
       |""".stripMargin
 

--- a/src/main/scala/uk/gov/nationalarchives/StatusProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/StatusProcessor.scala
@@ -48,7 +48,9 @@ class StatusProcessor[F[_] : Monad](input: Input, allPuidInformation: AllPuidInf
       matches <- ffid.matches
     } yield {
       val puidMatch = matches.puid.getOrElse("")
-      val disallowedReason = allPuidInformation.disallowedPuids.find(_.puid == puidMatch).map(_.reason)
+      val disallowedReason = allPuidInformation.disallowedPuids
+        .filter(_.active)
+        .find(_.puid == puidMatch).map(_.reason)
       val judgmentDisAllowedPuid = !allPuidInformation.allowedPuids.map(_.puid).contains(puidMatch)
       val reason = if (res.consignmentType == "judgment" && judgmentDisAllowedPuid) {
         NonJudgmentFormat
@@ -122,7 +124,7 @@ class StatusProcessor[F[_] : Monad](input: Input, allPuidInformation: AllPuidInf
         } else {
           Completed
         }
-        Status(i.consignmentId, ConsignmentType, ServerFFID, statusValue)
+        Status(i.consignmentId, ConsignmentType, ServerFFID, statusValue, overwrite = true)
       }).toList
     }
   }
@@ -151,7 +153,7 @@ class StatusProcessor[F[_] : Monad](input: Input, allPuidInformation: AllPuidInf
     fileClientChecks().map(checks => {
       val result = checks.find(_.statusValue == CompletedWithIssues).map(_.statusValue).getOrElse(Completed)
       input.results.headOption.map(res => {
-        Status(res.consignmentId, ConsignmentType, ClientChecks, result)
+        Status(res.consignmentId, ConsignmentType, ClientChecks, result, overwrite = true)
       }).toList
     })
   }

--- a/src/main/scala/uk/gov/nationalarchives/StatusProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/StatusProcessor.scala
@@ -2,7 +2,7 @@ package uk.gov.nationalarchives
 
 import cats.Monad
 import cats.implicits._
-import uk.gov.nationalarchives.Lambda.{File, Input, Status}
+import uk.gov.nationalarchives.BackendCheckUtils.{File, Input, Status}
 import uk.gov.nationalarchives.PuidRepository.AllPuidInformation
 
 import scala.util.Try
@@ -56,7 +56,7 @@ class StatusProcessor[F[_] : Monad](input: Input, allPuidInformation: AllPuidInf
         NonJudgmentFormat
       } else if (res.consignmentType == "standard" && Try(res.fileSize.toLong).getOrElse(0L) > 0) {
         disallowedReason.getOrElse(Success)
-      } else if (res.fileSize == "0") {
+      } else if (res.fileSize == "0" && disallowedReason.contains(ZeroByteFile)) {
         ZeroByteFile
       } else {
         Success

--- a/src/test/resources/input.json
+++ b/src/test/resources/input.json
@@ -48,5 +48,8 @@
   "redactedResults": {
     "redactedFiles": [],
     "errors": []
+  },
+  "statuses": {
+    "statuses": []
   }
 }


### PR DESCRIPTION
The consignment statuses already exist so we need to set overwrite =
true to allow them to be updated.

I was also checking non active disallowed reasons which was causing
problems.

Also, this lambda is now running in a step function.

There is a size limit of 256Kb for messages passed between steps and for large consignments, the message is more than this.

To solve this, each step reads its input from S3 and once it has carried out its step, writes the new output to S3 again.

I've updated this lambda to use the backend-check-utils classes and updated the test to work with calls to S3.