### PR TITLE
Fix status issues with multiple PUIDs

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/LambdaRunner.scala
+++ b/src/main/scala/uk/gov/nationalarchives/LambdaRunner.scala
@@ -5,7 +5,7 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 object LambdaRunner extends App {
   private val body =
     """{
-      |  "key": "a4c0e084-7562-46dd-9724-92ac9b64d149/d5cd3fb2-4869-4d28-9537-4655486a8a2d/results.json",
+      |  "key": "19286aee-5a39-4f11-bf35-738e22e553c3/3e0cf5f5-4630-45b7-98f8-a559ac324ce0/results.json",
       |  "bucket": "tdr-backend-checks-intg"
       |}
       |""".stripMargin

--- a/src/test/scala/uk/gov/nationalarchives/TestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/TestUtils.scala
@@ -57,7 +57,9 @@ class TestUtils extends AnyFlatSpec with TableDrivenPropertyChecks with MockitoS
           res1 <- sql"""CREATE TABLE public."AllowedPuids" ("PUID" text not null)""".update.run.transact(xa)
           res2 <- sql"""INSERT INTO "AllowedPuids" ("PUID") VALUES ('fmt/000') """.update.run.transact(xa)
           res3 <- sql"""CREATE TABLE public."DisallowedPuids" ("PUID" text not null, "Reason" text not null, "Active" boolean not null default true)""".update.run.transact(xa)
-          res4 <- sql"""INSERT INTO "DisallowedPuids" ("PUID", "Reason", "Active") VALUES ('fmt/001', 'Invalid', true), ('fmt/002', 'Inactive', false) """.update.run.transact(xa)
+          res4 <-
+            sql"""INSERT INTO "DisallowedPuids" ("PUID", "Reason", "Active") VALUES
+                 ('fmt/001', 'Invalid', true), ('fmt/002', 'Inactive', false), ('', 'ZeroByteFile', true) """.update.run.transact(xa)
         } yield List(res1, res2, res3, res4)).unsafeRunSync()
     }
     super.afterContainersStart(containers)


### PR DESCRIPTION
There are a few different fixes here.

The first is that if a file has more than one PUID, we were generating a
file status row for each PUID instead of one row for both. If one PUID
was allowed and one wasn't, the consignment status was showing as
Completed because one of the file statuses was a success. This now
checks all PUIDs and if any of them fail, the status is set to the
failure reason.

The second thing is that the list of successful PUIDs for the
ClientChecks status was reporting a success if *any* of the client
checks succeeded. This has been changed so it only reports success if
there are no failures at all.

The last is a change to the tests. We weren't checking what would happen
if ZeroByteFile was active in the DisallowedPuids table. It isn't in
prod at the moment but it could be switched on so I've added in another
test.
