### PR TITLE
Check for empty results first

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/StatusProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/StatusProcessor.scala
@@ -64,9 +64,12 @@ class StatusProcessor[F[_] : Monad](input: Input, allPuidInformation: AllPuidInf
 
   def checksumMatch(): F[List[Status]] = {
     input.results.map(result => {
-      val serverChecksum = result.fileCheckResults.checksum.map(_.sha256Checksum).headOption
+      val checksumResult = result.fileCheckResults.checksum
+      val serverChecksum = checksumResult.map(_.sha256Checksum).headOption
       val clientChecksum = result.clientChecksum
-      val statusValue = if (serverChecksum.contains(clientChecksum)) {
+      val statusValue = if(checksumResult.isEmpty) {
+        Failed
+      } else if (serverChecksum.contains(clientChecksum)) {
         Success
       } else {
         Mismatch

--- a/src/main/scala/uk/gov/nationalarchives/StatusProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/StatusProcessor.scala
@@ -49,12 +49,12 @@ class StatusProcessor[F[_] : Monad](input: Input, allPuidInformation: AllPuidInf
         .filter(_.active)
         .find(r => puidMatches.contains(r.puid)).map(_.reason)
       val judgmentDisAllowedPuid = !allPuidInformation.allowedPuids.map(_.puid).forall(a => puidMatches.contains(a))
-      val reason = if (result.consignmentType == "judgment" && judgmentDisAllowedPuid) {
+      val reason = if (fileFormat.isEmpty) {
+        Failed
+      } else if (result.consignmentType == "judgment" && judgmentDisAllowedPuid) {
         NonJudgmentFormat
       } else if (result.fileSize == "0" && disallowedReason.contains(ZeroByteFile)) {
         ZeroByteFile
-      } else if (fileFormat.isEmpty) {
-        Failed
       } else {
         disallowedReason.getOrElse(Success)
       }


### PR DESCRIPTION
We had a failed FFID check and the status was set to NonJudgmentFormat
because the FFID check was empty. While this is technically correct,
it's not what we're after so I've moved the empty check first so any
missing metadata will trigger the failed status.
