### PR TITLE
Handle 0 byte files FFID status correctly

### DIFF
--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -54,7 +54,8 @@ class LambdaTest extends TestUtils with BeforeAndAfterAll {
     ("standard", List("fmt/003"), "0", "Success"),
     ("standard", List("fmt/000", "fmt/001"), "0", "Invalid"),
     ("standard", List("fmt/000", "fmt/002"), "0", "Success"),
-    ("standard", List("fmt/001", "fmt/001"), "0", "Invalid")
+    ("standard", List("fmt/001", "fmt/001"), "0", "Invalid"),
+    ("standard", List("fmt/494", "fmt/002"), "0", "Success")
   )
 
   forAll(ffidResults)((consignmentType, puids, fileSize, expectedStatus) => {
@@ -212,7 +213,7 @@ class LambdaTest extends TestUtils with BeforeAndAfterAll {
     ("checksum", "", "fmt/000", "1", "CompletedWithIssues"),
     ("", "", "fmt/001", "1", "CompletedWithIssues"),
     ("checksum", "path", "fmt/001", "1", "Completed"),
-    ("checksum", "path", "", "0", "CompletedWithIssues"),
+    ("checksum", "path", "", "0", "Completed"),
     ("checksum", "path", "fmt/000", "1", "Completed")
   )
 

--- a/src/test/scala/uk/gov/nationalarchives/TestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/TestUtils.scala
@@ -59,7 +59,10 @@ class TestUtils extends AnyFlatSpec with TableDrivenPropertyChecks with MockitoS
           res3 <- sql"""CREATE TABLE public."DisallowedPuids" ("PUID" text not null, "Reason" text not null, "Active" boolean not null default true)""".update.run.transact(xa)
           res4 <-
             sql"""INSERT INTO "DisallowedPuids" ("PUID", "Reason", "Active") VALUES
-                 ('fmt/001', 'Invalid', true), ('fmt/002', 'Inactive', false), ('', 'ZeroByteFile', true) """.update.run.transact(xa)
+                 ('fmt/001', 'Invalid', true),
+                 ('fmt/002', 'Inactive', false),
+                 ('', 'ZeroByteFile', false),
+                 ('fmt/494', 'PasswordProtected', true) """.update.run.transact(xa)
         } yield List(res1, res2, res3, res4)).unsafeRunSync()
     }
     super.afterContainersStart(containers)


### PR DESCRIPTION
TDR's current behaviour is to allow 0 byte files in a transfer but not password protected files

0 byte files cannot be password protected but in some instances PRONOM mis-identifies as password protected

PRONOM uses the file extension to identify file type with 0 byte file.

As a result for '.docx' extension PRONOM includes the encrypted type ('Microsoft Office Encrypted Document') as one of the identified types and TDR was incorrectly flagging such files as password protected and stopping the transfer

The unit tests have been altered for reflect the currect TDR behaviour of 0 byte files not being disallowed