### PR TITLE
Use checksum for empty files

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ The lambda processes the following file statuses for each file.
 
 ### FFID
 * If the consignment type is judgment and the puid is not in the AllowedPuids table then `NonJudgmentFormat`.
-* If the server checksum matches the zero byte file checksum (`e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`) or the UTF-8 BOM file checksum (`f01a374e9c81e3db89b3a42940c4d6a5447684986a1296e42bf13f196eed6295`) then `EmptyFile`.
+* If the server checksum matches the zero byte file checksum (`e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`) or the UTF-8 BOM file checksum (`f01a374e9c81e3db89b3a42940c4d6a5447684986a1296e42bf13f196eed6295`) then `ZeroByteFile`.
+* If the file size is `0` then `ZeroByteFile`.
 * If the consignment type is standard and the puid is in the DisallowedPuids table and is active then get the status from the `Reason` column.
 * Otherwise `Success`.
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ The lambda processes the following file statuses for each file.
 
 ### FFID
 * If the consignment type is judgment and the puid is not in the AllowedPuids table then `NonJudgmentFormat`.
+* If the server checksum matches the zero byte file checksum (`e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`) or the UTF-8 BOM file checksum (`f01a374e9c81e3db89b3a42940c4d6a5447684986a1296e42bf13f196eed6295`) then `EmptyFile`.
 * If the consignment type is standard and the puid is in the DisallowedPuids table and is active then get the status from the `Reason` column.
-* If the file size is zero then `ZeroByteFile`.
 * Otherwise `Success`.
 
 ### ChecksumMatch

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
   lazy val testContainersPostgres = "com.dimafeng" %% "testcontainers-scala-postgresql" % testContainersVersion
   lazy val mockito = "org.mockito" %% "mockito-scala" % "2.1.0"
   lazy val wiremock = "com.github.tomakehurst" % "wiremock" % "3.0.1"
-  lazy val metadataSchema =  "uk.gov.nationalarchives" %% "da-metadata-schema"  % "0.0.124-SNAPSHOT"
+  lazy val metadataSchema =  "uk.gov.nationalarchives" %% "da-metadata-schema"  % "0.0.124"
   lazy val catsEffect = "org.typelevel" %% "cats-effect" % "3.7.0"
   lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.285"
   lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.463"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
 
   lazy val awsS3 = "software.amazon.awssdk" % "s3" % awsVersion
   lazy val awsSsm = "software.amazon.awssdk" % "ssm" % awsVersion
-  lazy val snsUtils = "uk.gov.nationalarchives" %% "sns-utils" % "0.1.319"
+  lazy val snsUtils = "uk.gov.nationalarchives" %% "sns-utils" % "0.1.320"
   lazy val backendCheckUtils = "uk.gov.nationalarchives" %% "tdr-backend-checks-utils" % "0.1.192"
   lazy val circeCore = "io.circe" %% "circe-core" % circeVersion
   lazy val circeParser = "io.circe" %% "circe-parser" % circeVersion
@@ -19,11 +19,11 @@ object Dependencies {
   lazy val testContainersPostgres = "com.dimafeng" %% "testcontainers-scala-postgresql" % testContainersVersion
   lazy val mockito = "org.mockito" %% "mockito-scala" % "2.1.0"
   lazy val wiremock = "com.github.tomakehurst" % "wiremock" % "3.0.1"
-  lazy val metadataSchema =  "uk.gov.nationalarchives" %% "da-metadata-schema" % "0.0.122"
-  lazy val catsEffect = "org.typelevel" %% "cats-effect" % "3.6.3"
-  lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.283"
-  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.461"
-  lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.277"
+  lazy val metadataSchema =  "uk.gov.nationalarchives" %% "da-metadata-schema"  % "0.0.124-SNAPSHOT"
+  lazy val catsEffect = "org.typelevel" %% "cats-effect" % "3.7.0"
+  lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.285"
+  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.463"
+  lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.278"
   lazy val typesafeConfig = "com.typesafe" % "config" % "1.4.6"
   lazy val catsEffectTesting = "org.typelevel" %% "cats-effect-testing-scalatest" % "1.8.0"
 }

--- a/src/main/scala/uk/gov/nationalarchives/PuidJsonReader.scala
+++ b/src/main/scala/uk/gov/nationalarchives/PuidJsonReader.scala
@@ -4,13 +4,14 @@ import cats.effect.IO
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.circe.generic.auto._
 import io.circe.jawn.decode
-import uk.gov.nationalarchives.PuidJsonReader.{AllPuidInformation, AllowedPuids, DisallowedPuids}
+import uk.gov.nationalarchives.PuidJsonReader.{AllPuidInformation, AllowedPuids, DisallowedPuids, PuidChecksumEntry}
 
 import scala.io.Source
 import scala.util.Using
 
 class PuidJsonReader(allowedPuidsResult: Either[io.circe.Error, List[AllowedPuids]],
-                     disallowedPuidsResult: Either[io.circe.Error, List[DisallowedPuids]]) {
+                     disallowedPuidsResult: Either[io.circe.Error, List[DisallowedPuids]],
+                     puidChecksumsResult: Either[io.circe.Error, List[PuidChecksumEntry]]) {
 
   private def allowedPuids(): IO[List[AllowedPuids]] = {
     IO.fromEither(allowedPuidsResult)
@@ -20,26 +21,35 @@ class PuidJsonReader(allowedPuidsResult: Either[io.circe.Error, List[AllowedPuid
     IO.fromEither(disallowedPuidsResult)
   }
 
+  private def puidChecksums(): IO[List[PuidChecksumEntry]] = {
+    IO.fromEither(puidChecksumsResult)
+  }
+
   def allPuids: IO[AllPuidInformation] = for {
     allowedPuids <- allowedPuids()
     disallowedPuids <- disallowedPuids()
-  } yield AllPuidInformation(allowedPuids, disallowedPuids)
+    puidChecksums <- puidChecksums()
+  } yield AllPuidInformation(allowedPuids, disallowedPuids, puidChecksums)
 }
 
 object PuidJsonReader {
 
   private val allowedPuidsConfiguration: String = "puids/allowed-puids.json"
   private val disallowedPuidConfiguration: String = "puids/disallowed-puids.json"
+  private val puidChecksumsConfiguration: String = "puids/puid-checksums.json"
 
-  case class AllPuidInformation(allowedPuids: List[AllowedPuids], disallowedPuids: List[DisallowedPuids])
+  case class AllPuidInformation(allowedPuids: List[AllowedPuids], disallowedPuids: List[DisallowedPuids], puidChecksums: List[PuidChecksumEntry])
 
   case class DisallowedPuids(puid: String, puidDescription: String, reason: String, active: Boolean)
   case class AllowedPuids(puid: String, puidDescription: String, consignmentType: String)
+  case class PuidChecksumDetail(checksum: String, checksumDescription: String)
+  case class PuidChecksumEntry(puid: String, checksums: List[PuidChecksumDetail])
 
   def apply(): PuidJsonReader = {
     val allowedPuidsResult = decode[List[AllowedPuids]](readJson(allowedPuidsConfiguration))
     val disallowedPuidsResult = decode[List[DisallowedPuids]](readJson(disallowedPuidConfiguration))
-    new PuidJsonReader(allowedPuidsResult, disallowedPuidsResult)
+    val puidChecksumsResult = decode[List[PuidChecksumEntry]](readJson(puidChecksumsConfiguration))
+    new PuidJsonReader(allowedPuidsResult, disallowedPuidsResult, puidChecksumsResult)
   }
 
   private def readJson(jsonFile: String): String = {

--- a/src/main/scala/uk/gov/nationalarchives/StatusProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/StatusProcessor.scala
@@ -17,7 +17,9 @@ class StatusProcessor[F[_] : Monad](input: Input, allPuidInformation: AllPuidInf
   private val Failed = "Failed"
   private val ServerChecksum = "ServerChecksum"
   private val ServerAntivirus = "ServerAntivirus"
-  private val ZeroByteFile = "ZeroByteFile"
+  private val EmptyFile = "EmptyFile"
+  private val ZeroByteChecksum = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  private val BomFileChecksum = "f01a374e9c81e3db89b3a42940c4d6a5447684986a1296e42bf13f196eed6295"
   private val ClientChecksum = "ClientChecksum"
   private val ClientFilePath = "ClientFilePath"
   private val FFIDStatus = "FFID"
@@ -51,9 +53,12 @@ class StatusProcessor[F[_] : Monad](input: Input, allPuidInformation: AllPuidInf
         .find(r => puidMatches.contains(r.puid)).map(_.reason)
       val judgmentDisAllowedPuid = !puidMatches.forall(p => allPuidInformation.allowedPuids.map(_.puid).contains(p))
 
+      val serverChecksum = result.fileCheckResults.checksum.map(_.sha256Checksum).headOption
+      val isEmptyFile = serverChecksum.contains(ZeroByteChecksum) || serverChecksum.contains(BomFileChecksum)
+
       val reason = result match {
         case r if r.consignmentType == "judgment" && judgmentDisAllowedPuid => NonJudgmentFormat
-        case r if r.fileSize == "0" => ZeroByteFile
+        case _ if isEmptyFile => EmptyFile
         case _ if fileFormat.isEmpty => Failed
         case _ => disallowedReason.getOrElse(Success)
       }
@@ -153,7 +158,7 @@ class StatusProcessor[F[_] : Monad](input: Input, allPuidInformation: AllPuidInf
       val allStatuses = ffid ++ clientChecksum ++ clientFilePath ++ redactions
       val failedIds = allStatuses.filter(s => {
         if(s.statusName == FFIDStatus) {
-          s.statusValue == ZeroByteFile
+          s.statusValue == EmptyFile
         } else {
           s.statusValue != Success
         }

--- a/src/main/scala/uk/gov/nationalarchives/StatusProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/StatusProcessor.scala
@@ -18,8 +18,6 @@ class StatusProcessor[F[_] : Monad](input: Input, allPuidInformation: AllPuidInf
   private val ServerChecksum = "ServerChecksum"
   private val ServerAntivirus = "ServerAntivirus"
   private val ZeroByteFile = "ZeroByteFile"
-  private val ZeroByteChecksum = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-  private val BomFileChecksum = "f01a374e9c81e3db89b3a42940c4d6a5447684986a1296e42bf13f196eed6295"
   private val ClientChecksum = "ClientChecksum"
   private val ClientFilePath = "ClientFilePath"
   private val FFIDStatus = "FFID"
@@ -53,8 +51,13 @@ class StatusProcessor[F[_] : Monad](input: Input, allPuidInformation: AllPuidInf
         .find(r => puidMatches.contains(r.puid)).map(_.reason)
       val judgmentDisAllowedPuid = !puidMatches.forall(p => allPuidInformation.allowedPuids.map(_.puid).contains(p))
 
+      val emptyFileChecksums: Set[String] = allPuidInformation.puidChecksums
+        .filter(_.puid == "zeroByteFile")
+        .flatMap(_.checksums.map(_.checksum))
+        .toSet
+
       val serverChecksum = result.fileCheckResults.checksum.map(_.sha256Checksum).headOption
-      val isEmptyFile = serverChecksum.contains(ZeroByteChecksum) || serverChecksum.contains(BomFileChecksum)
+      val isEmptyFile = serverChecksum.exists(emptyFileChecksums.contains)
 
       val reason = result match {
         case r if r.consignmentType == "judgment" && judgmentDisAllowedPuid => NonJudgmentFormat

--- a/src/main/scala/uk/gov/nationalarchives/StatusProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/StatusProcessor.scala
@@ -17,7 +17,7 @@ class StatusProcessor[F[_] : Monad](input: Input, allPuidInformation: AllPuidInf
   private val Failed = "Failed"
   private val ServerChecksum = "ServerChecksum"
   private val ServerAntivirus = "ServerAntivirus"
-  private val EmptyFile = "EmptyFile"
+  private val ZeroByteFile = "ZeroByteFile"
   private val ZeroByteChecksum = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   private val BomFileChecksum = "f01a374e9c81e3db89b3a42940c4d6a5447684986a1296e42bf13f196eed6295"
   private val ClientChecksum = "ClientChecksum"
@@ -58,7 +58,8 @@ class StatusProcessor[F[_] : Monad](input: Input, allPuidInformation: AllPuidInf
 
       val reason = result match {
         case r if r.consignmentType == "judgment" && judgmentDisAllowedPuid => NonJudgmentFormat
-        case _ if isEmptyFile => EmptyFile
+        case _ if isEmptyFile => ZeroByteFile
+        case r if r.fileSize == "0" => ZeroByteFile
         case _ if fileFormat.isEmpty => Failed
         case _ => disallowedReason.getOrElse(Success)
       }
@@ -158,7 +159,7 @@ class StatusProcessor[F[_] : Monad](input: Input, allPuidInformation: AllPuidInf
       val allStatuses = ffid ++ clientChecksum ++ clientFilePath ++ redactions
       val failedIds = allStatuses.filter(s => {
         if(s.statusName == FFIDStatus) {
-          s.statusValue == EmptyFile
+          s.statusValue == ZeroByteFile
         } else {
           s.statusValue != Success
         }

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -74,9 +74,10 @@ class LambdaTest extends TestUtils with BeforeAndAfterAll {
       val matches = puids.map(puid => {
         FFIDMetadataInputMatches(Option("extension"), "identificationBasis", Option(puid), Some(false), Some("format-name"))
       })
+      val fileId = UUID.randomUUID()
       val checksumResults = List(ChecksumResult(serverChecksum, UUID.randomUUID()))
-      val fileChecks = FileCheckResults(Nil, checksumResults, FFID(UUID.randomUUID(), "software", "softwareVersion", "binarySignature", "containerSignature", "method", matches) :: Nil)
-      val files = File(consignmentId, UUID.randomUUID(), UUID.randomUUID(), consignmentType, fileSize, "checksum", "originalPath", Some("source-bucket"), Some("object/key"), fileChecks) :: Nil
+      val fileChecks = FileCheckResults(Nil, checksumResults, FFID(fileId, "software", "softwareVersion", "binarySignature", "containerSignature", "method", matches) :: Nil)
+      val files = File(consignmentId, fileId, UUID.randomUUID(), consignmentType, fileSize, "checksum", "originalPath", Some("source-bucket"), Some("object/key"), fileChecks) :: Nil
       val inputString = Input(files, RedactedResults(Nil, Nil), StatusResult(Nil)).asJson.printWith(Printer.noSpaces)
       val s3Input = putJsonFile(S3Input("testKey", "testBucket"), inputString).asJson.printWith(noSpaces)
       val input = new ByteArrayInputStream(s3Input.getBytes())
@@ -160,9 +161,10 @@ class LambdaTest extends TestUtils with BeforeAndAfterAll {
       
       val consignmentId = UUID.randomUUID()
       val files = puids.map(puid => {
+        val fileId = UUID.randomUUID()
         val matches = FFIDMetadataInputMatches(Option("extension"),"identificationBasis" ,Option(puid), Some(false), Some("format-name")) :: Nil
-        val fileChecks = FileCheckResults(Nil, Nil, FFID(UUID.randomUUID(), "software", "softwareVersion", "binarySignature", "containerSignature", "method", matches) :: Nil)
-        File(consignmentId, UUID.randomUUID(), UUID.randomUUID(), "standard", "1", "checksum", "originalPath", Some("source-bucket"), Some("object/key"), fileChecks)
+        val fileChecks = FileCheckResults(Nil, Nil, FFID(fileId, "software", "softwareVersion", "binarySignature", "containerSignature", "method", matches) :: Nil)
+        File(consignmentId, fileId, UUID.randomUUID(), "standard", "1", "checksum", "originalPath", Some("source-bucket"), Some("object/key"), fileChecks)
       })
       val inputString = Input(files, RedactedResults(Nil, Nil), StatusResult(Nil)).asJson.printWith(Printer.noSpaces)
       val s3Input = putJsonFile(S3Input("testKey", "testBucket"), inputString).asJson.printWith(noSpaces)
@@ -296,9 +298,10 @@ class LambdaTest extends TestUtils with BeforeAndAfterAll {
 
   forAll(missingInfo)((missingInfoCount, providedInfoCount, expectedConsignmentStatus) => {
     val antivirus = Antivirus(UUID.randomUUID(), "software", "softwareVersion", "databaseVersion", "", 1) :: Nil
-    val ffid = FFID(UUID.randomUUID(), "software", "softwareVersion", "binarySignature", "containerSignature", "method", Nil) :: Nil
+    val fileId = UUID.randomUUID()
+    val ffid = FFID(fileId, "software", "softwareVersion", "binarySignature", "containerSignature", "method", Nil) :: Nil
     val checksum = ChecksumResult("checksum", UUID.randomUUID()) :: Nil
-    val createFile = File(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), "standard", "1", "checksum", "originalPath", Some("source-bucket"), Some("object/key"), _)
+    val createFile = File(UUID.randomUUID(), fileId, UUID.randomUUID(), "standard", "1", "checksum", "originalPath", Some("source-bucket"), Some("object/key"), _)
     val providedInfoFiles = List.fill(providedInfoCount)("")
       .map(_ => createFile(FileCheckResults(antivirus, checksum, ffid)))
 
@@ -370,11 +373,12 @@ class LambdaTest extends TestUtils with BeforeAndAfterAll {
     val consignmentId = UUID.randomUUID()
     val userId: UUID = UUID.randomUUID()
     val matches = FFIDMetadataInputMatches(Option("extension"), "identificationBasis", Option(allowedJudgmentPuid), Some(false), Some("format-name")) :: Nil
-    val fileChecks = FileCheckResults(Nil, Nil, FFID(UUID.randomUUID(), "software", "softwareVersion", "binarySignature", "containerSignature", "method", matches) :: Nil)
+    val fileId = UUID.randomUUID()
+    val fileChecks = FileCheckResults(Nil, Nil, FFID(fileId, "software", "softwareVersion", "binarySignature", "containerSignature", "method", matches) :: Nil)
 
     val file = uk.gov.nationalarchives.BackendCheckUtils.File(
       consignmentId,
-      UUID.randomUUID(),
+      fileId,
       userId,
       "standard",
       "FileSize",

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -207,22 +207,6 @@ class LambdaTest extends TestUtils with BeforeAndAfterAll {
       serverAVStatuses.head.statusValue should equal(expectedResult)
     }
   })
-  val fileClientChecksResults: TableFor5[String, String, String, String, String] = Table(
-    ("clientChecksum", "clientFilePath", "ffid", "serverChecksum", "expectedStatus"),
-    ("", "path", s"$allowedJudgmentPuid", "validChecksum", "CompletedWithIssues"),
-    ("checksum", "", s"$allowedJudgmentPuid", "validChecksum", "CompletedWithIssues"),
-    ("", "", s"$activeDisallowedStandardPuid", "validChecksum", "CompletedWithIssues"),
-    ("checksum", "path", s"$activeDisallowedStandardPuid", "validChecksum", "Completed"),
-    ("checksum", "path", "", zeroByteChecksum, "CompletedWithIssues"),
-    ("checksum", "path", s"$allowedJudgmentPuid", "validChecksum", "Completed")
-  )
-  val consignmentClientChecksResults: TableFor2[List[String], String] = Table(
-    ("fileClientChecks", "expectedResult"),
-    (List("Completed", "CompletedWithIssues"), "CompletedWithIssues"),
-    (List("CompletedWithIssues", "CompletedWithIssues"), "CompletedWithIssues"),
-    (List("Completed", "Completed"), "Completed"),
-    (List("Completed"), "Completed"),
-  )
 
   forAll(redactionResults)((description, redactedResults, expectedResult) => {
     "run" should s"return the expected consignment status $expectedResult for $description" in {
@@ -251,7 +235,15 @@ class LambdaTest extends TestUtils with BeforeAndAfterAll {
     (0, 1, Option("Completed")),
     (0, 0, None),
   )
-
+  val fileClientChecksResults: TableFor5[String, String, String, String, String] = Table(
+    ("clientChecksum", "clientFilePath", "ffid", "serverChecksum", "expectedStatus"),
+    ("", "path", s"$allowedJudgmentPuid", "validChecksum", "CompletedWithIssues"),
+    ("checksum", "", s"$allowedJudgmentPuid", "validChecksum", "CompletedWithIssues"),
+    ("", "", s"$activeDisallowedStandardPuid", "validChecksum", "CompletedWithIssues"),
+    ("checksum", "path", s"$activeDisallowedStandardPuid", "validChecksum", "Completed"),
+    ("checksum", "path", "", zeroByteChecksum, "CompletedWithIssues"),
+    ("checksum", "path", s"$allowedJudgmentPuid", "validChecksum", "Completed")
+  )
   forAll(fileClientChecksResults)((clientChecksum, clientFilePath, ffid, serverChecksum, expectedStatus) => {
     "run" should s"return $expectedStatus for $clientChecksum, $clientFilePath, $ffid" in {
       val inputReplacements = Map(
@@ -271,6 +263,13 @@ class LambdaTest extends TestUtils with BeforeAndAfterAll {
     wiremockS3Server.start()
   }
 
+  val consignmentClientChecksResults: TableFor2[List[String], String] = Table(
+    ("fileClientChecks", "expectedResult"),
+    (List("Completed", "CompletedWithIssues"), "CompletedWithIssues"),
+    (List("CompletedWithIssues", "CompletedWithIssues"), "CompletedWithIssues"),
+    (List("Completed", "Completed"), "Completed"),
+    (List("Completed"), "Completed"),
+  )
   forAll(consignmentClientChecksResults)((fileClientChecks, expectedResult) => {
     "run" should s"return the expected consignment status $expectedResult for client checks ${fileClientChecks.mkString(" ")}" in {
       val consignmentId = UUID.randomUUID()

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -19,17 +19,21 @@ import scala.io.Source
 
 class LambdaTest extends TestUtils with BeforeAndAfterAll {
 
+  val zeroByteChecksum = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  val bomFileChecksum = "f01a374e9c81e3db89b3a42940c4d6a5447684986a1296e42bf13f196eed6295"
+
   val ffidResults: TableFor4[String, List[String], String, String] = Table(
-    ("consignmentType", "puid", "fileSize", "result"),
-    ("judgment", List(s"$disallowedJudgmentPuid"), "1", "NonJudgmentFormat"),
-    ("judgment", List(s"$allowedJudgmentPuid"), "1", "Success"),
-    ("standard", List(s"$inactiveDisallowedStandardPuid"), "1", "Success"),
-    ("standard", List(s"$activeDisallowedStandardPuid"), "1", "Zip"),
-    ("standard", List(s"$allowedStandardPuid"), "0", "ZeroByteFile"),
-    ("standard", List(s"$allowedJudgmentPuid", s"$activeDisallowedStandardPuid"), "0", "ZeroByteFile"),
-    ("standard", List(s"$allowedJudgmentPuid", s"$inactiveDisallowedStandardPuid"), "0", "ZeroByteFile"),
-    ("standard", List(s"$activeDisallowedStandardPuid", s"$activeDisallowedStandardPuid"), "0", "ZeroByteFile"),
-    ("standard", List(s"$passwordProtectedPuid", s"$inactiveDisallowedStandardPuid"), "0", "ZeroByteFile")
+    ("consignmentType", "puid", "serverChecksum", "result"),
+    ("judgment", List(s"$disallowedJudgmentPuid"), "validChecksum", "NonJudgmentFormat"),
+    ("judgment", List(s"$allowedJudgmentPuid"), "validChecksum", "Success"),
+    ("standard", List(s"$inactiveDisallowedStandardPuid"), "validChecksum", "Success"),
+    ("standard", List(s"$activeDisallowedStandardPuid"), "validChecksum", "Zip"),
+    ("standard", List(s"$allowedStandardPuid"), zeroByteChecksum, "EmptyFile"),
+    ("standard", List(s"$allowedJudgmentPuid", s"$activeDisallowedStandardPuid"), zeroByteChecksum, "EmptyFile"),
+    ("standard", List(s"$allowedJudgmentPuid", s"$inactiveDisallowedStandardPuid"), zeroByteChecksum, "EmptyFile"),
+    ("standard", List(s"$activeDisallowedStandardPuid", s"$activeDisallowedStandardPuid"), zeroByteChecksum, "EmptyFile"),
+    ("standard", List(s"$passwordProtectedPuid", s"$inactiveDisallowedStandardPuid"), zeroByteChecksum, "EmptyFile"),
+    ("standard", List(s"$allowedStandardPuid"), bomFileChecksum, "EmptyFile")
   )
   val avResults: TableFor2[String, String] = Table(
     ("avResult", "expectedStatus"),
@@ -61,15 +65,16 @@ class LambdaTest extends TestUtils with BeforeAndAfterAll {
     ("mismatch", "match", "Mismatch")
   )
 
-  forAll(ffidResults)((consignmentType, puids, fileSize, expectedStatus) => {
-    "run" should s"return a $expectedStatus if the $consignmentType puid is ${puids.mkString(",")} and file size is $fileSize" in {
-      
+  forAll(ffidResults)((consignmentType, puids, serverChecksum, expectedStatus) => {
+    "run" should s"return a $expectedStatus if the $consignmentType puid is ${puids.mkString(",")} and server checksum is $serverChecksum" in {
+
       val consignmentId = UUID.randomUUID()
       val matches = puids.map(puid => {
         FFIDMetadataInputMatches(Option("extension"), "identificationBasis", Option(puid), Some(false), Some("format-name"))
       })
-      val fileChecks = FileCheckResults(Nil, Nil, FFID(UUID.randomUUID(), "software", "softwareVersion", "binarySignature", "containerSignature", "method", matches) :: Nil)
-      val files = File(consignmentId, UUID.randomUUID(), UUID.randomUUID(), consignmentType, fileSize, "checksum", "originalPath", Some("source-bucket"), Some("object/key"), fileChecks) :: Nil
+      val checksumResults = List(ChecksumResult(serverChecksum, UUID.randomUUID()))
+      val fileChecks = FileCheckResults(Nil, checksumResults, FFID(UUID.randomUUID(), "software", "softwareVersion", "binarySignature", "containerSignature", "method", matches) :: Nil)
+      val files = File(consignmentId, UUID.randomUUID(), UUID.randomUUID(), consignmentType, "1", "checksum", "originalPath", Some("source-bucket"), Some("object/key"), fileChecks) :: Nil
       val inputString = Input(files, RedactedResults(Nil, Nil), StatusResult(Nil)).asJson.printWith(Printer.noSpaces)
       val s3Input = putJsonFile(S3Input("testKey", "testBucket"), inputString).asJson.printWith(noSpaces)
       val input = new ByteArrayInputStream(s3Input.getBytes())
@@ -199,13 +204,13 @@ class LambdaTest extends TestUtils with BeforeAndAfterAll {
     }
   })
   val fileClientChecksResults: TableFor5[String, String, String, String, String] = Table(
-    ("clientChecksum", "clientFilePath", "ffid", "fileSize", "expectedStatus"),
-    ("", "path", s"$allowedJudgmentPuid", "1", "CompletedWithIssues"),
-    ("checksum", "", s"$allowedJudgmentPuid", "1", "CompletedWithIssues"),
-    ("", "", s"$activeDisallowedStandardPuid", "1", "CompletedWithIssues"),
-    ("checksum", "path", s"$activeDisallowedStandardPuid", "1", "Completed"),
-    ("checksum", "path", "", "0", "CompletedWithIssues"),
-    ("checksum", "path", s"$allowedJudgmentPuid", "1", "Completed")
+    ("clientChecksum", "clientFilePath", "ffid", "serverChecksum", "expectedStatus"),
+    ("", "path", s"$allowedJudgmentPuid", "validChecksum", "CompletedWithIssues"),
+    ("checksum", "", s"$allowedJudgmentPuid", "validChecksum", "CompletedWithIssues"),
+    ("", "", s"$activeDisallowedStandardPuid", "validChecksum", "CompletedWithIssues"),
+    ("checksum", "path", s"$activeDisallowedStandardPuid", "validChecksum", "Completed"),
+    ("checksum", "path", "", zeroByteChecksum, "CompletedWithIssues"),
+    ("checksum", "path", s"$allowedJudgmentPuid", "validChecksum", "Completed")
   )
   val consignmentClientChecksResults: TableFor2[List[String], String] = Table(
     ("fileClientChecks", "expectedResult"),
@@ -243,14 +248,14 @@ class LambdaTest extends TestUtils with BeforeAndAfterAll {
     (0, 0, None),
   )
 
-  forAll(fileClientChecksResults)((clientChecksum, clientFilePath, ffid, fileSize, expectedStatus) => {
+  forAll(fileClientChecksResults)((clientChecksum, clientFilePath, ffid, serverChecksum, expectedStatus) => {
     "run" should s"return $expectedStatus for $clientChecksum, $clientFilePath, $ffid" in {
       val inputReplacements = Map(
         "ClientChecksum" -> clientChecksum,
         "ClientFilePath" -> clientFilePath,
         "FFID" -> ffid,
         "ConsignmentType" -> "standard",
-        "FileSize" -> fileSize
+        "ServerChecksum" -> serverChecksum
       )
       val status = getStatus(inputReplacements, "ClientChecks", "Consignment")
       status should equal(expectedStatus)
@@ -267,7 +272,7 @@ class LambdaTest extends TestUtils with BeforeAndAfterAll {
       val consignmentId = UUID.randomUUID()
       val files: List[File] = fileClientChecks map {
         case "Completed" => File(consignmentId, UUID.randomUUID(), UUID.randomUUID(), "standard", "1", "checksum", "originalPath", Some("source-bucket"), Some("object/key"), FileCheckResults(Nil, Nil, Nil))
-        case "CompletedWithIssues" => File(consignmentId, UUID.randomUUID(), UUID.randomUUID(), "standard", "0", "", "originalPath", Some("source-bucket"), Some("object/key"), FileCheckResults(Nil, Nil, Nil))
+        case "CompletedWithIssues" => File(consignmentId, UUID.randomUUID(), UUID.randomUUID(), "standard", "1", "", "originalPath", Some("source-bucket"), Some("object/key"), FileCheckResults(Nil, Nil, Nil))
       }
       val inputString = Input(files, RedactedResults(Nil, Nil), StatusResult(Nil)).asJson.printWith(Printer.noSpaces)
       val s3Input = putJsonFile(S3Input("testKey", "testBucket"), inputString).asJson.printWith(noSpaces)

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -22,18 +22,20 @@ class LambdaTest extends TestUtils with BeforeAndAfterAll {
   val zeroByteChecksum = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   val bomFileChecksum = "f01a374e9c81e3db89b3a42940c4d6a5447684986a1296e42bf13f196eed6295"
 
-  val ffidResults: TableFor4[String, List[String], String, String] = Table(
-    ("consignmentType", "puid", "serverChecksum", "result"),
-    ("judgment", List(s"$disallowedJudgmentPuid"), "validChecksum", "NonJudgmentFormat"),
-    ("judgment", List(s"$allowedJudgmentPuid"), "validChecksum", "Success"),
-    ("standard", List(s"$inactiveDisallowedStandardPuid"), "validChecksum", "Success"),
-    ("standard", List(s"$activeDisallowedStandardPuid"), "validChecksum", "Zip"),
-    ("standard", List(s"$allowedStandardPuid"), zeroByteChecksum, "EmptyFile"),
-    ("standard", List(s"$allowedJudgmentPuid", s"$activeDisallowedStandardPuid"), zeroByteChecksum, "EmptyFile"),
-    ("standard", List(s"$allowedJudgmentPuid", s"$inactiveDisallowedStandardPuid"), zeroByteChecksum, "EmptyFile"),
-    ("standard", List(s"$activeDisallowedStandardPuid", s"$activeDisallowedStandardPuid"), zeroByteChecksum, "EmptyFile"),
-    ("standard", List(s"$passwordProtectedPuid", s"$inactiveDisallowedStandardPuid"), zeroByteChecksum, "EmptyFile"),
-    ("standard", List(s"$allowedStandardPuid"), bomFileChecksum, "EmptyFile")
+  val ffidResults: TableFor5[String, List[String], String, String, String] = Table(
+    ("consignmentType", "puid", "serverChecksum", "fileSize", "result"),
+    ("judgment", List(s"$disallowedJudgmentPuid"), "validChecksum", "1", "NonJudgmentFormat"),
+    ("judgment", List(s"$allowedJudgmentPuid"), "validChecksum", "1", "Success"),
+    ("standard", List(s"$inactiveDisallowedStandardPuid"), "validChecksum", "1", "Success"),
+    ("standard", List(s"$activeDisallowedStandardPuid"), "validChecksum", "1", "Zip"),
+    ("standard", List(s"$allowedStandardPuid"), zeroByteChecksum, "1", "ZeroByteFile"),
+    ("standard", List(s"$allowedJudgmentPuid", s"$activeDisallowedStandardPuid"), zeroByteChecksum, "1", "ZeroByteFile"),
+    ("standard", List(s"$allowedJudgmentPuid", s"$inactiveDisallowedStandardPuid"), zeroByteChecksum, "1", "ZeroByteFile"),
+    ("standard", List(s"$activeDisallowedStandardPuid", s"$activeDisallowedStandardPuid"), zeroByteChecksum, "1", "ZeroByteFile"),
+    ("standard", List(s"$passwordProtectedPuid", s"$inactiveDisallowedStandardPuid"), zeroByteChecksum, "1", "ZeroByteFile"),
+    ("standard", List(s"$allowedStandardPuid"), bomFileChecksum, "1", "ZeroByteFile"),
+    ("standard", List(s"$allowedStandardPuid"), "validChecksum", "0", "ZeroByteFile"),
+    ("standard", List(s"$activeDisallowedStandardPuid"), "validChecksum", "0", "ZeroByteFile")
   )
   val avResults: TableFor2[String, String] = Table(
     ("avResult", "expectedStatus"),
@@ -65,8 +67,8 @@ class LambdaTest extends TestUtils with BeforeAndAfterAll {
     ("mismatch", "match", "Mismatch")
   )
 
-  forAll(ffidResults)((consignmentType, puids, serverChecksum, expectedStatus) => {
-    "run" should s"return a $expectedStatus if the $consignmentType puid is ${puids.mkString(",")} and server checksum is $serverChecksum" in {
+  forAll(ffidResults)((consignmentType, puids, serverChecksum, fileSize, expectedStatus) => {
+    "run" should s"return a $expectedStatus if the $consignmentType puid is ${puids.mkString(",")} and server checksum is $serverChecksum and fileSize is $fileSize" in {
 
       val consignmentId = UUID.randomUUID()
       val matches = puids.map(puid => {
@@ -74,7 +76,7 @@ class LambdaTest extends TestUtils with BeforeAndAfterAll {
       })
       val checksumResults = List(ChecksumResult(serverChecksum, UUID.randomUUID()))
       val fileChecks = FileCheckResults(Nil, checksumResults, FFID(UUID.randomUUID(), "software", "softwareVersion", "binarySignature", "containerSignature", "method", matches) :: Nil)
-      val files = File(consignmentId, UUID.randomUUID(), UUID.randomUUID(), consignmentType, "1", "checksum", "originalPath", Some("source-bucket"), Some("object/key"), fileChecks) :: Nil
+      val files = File(consignmentId, UUID.randomUUID(), UUID.randomUUID(), consignmentType, fileSize, "checksum", "originalPath", Some("source-bucket"), Some("object/key"), fileChecks) :: Nil
       val inputString = Input(files, RedactedResults(Nil, Nil), StatusResult(Nil)).asJson.printWith(Printer.noSpaces)
       val s3Input = putJsonFile(S3Input("testKey", "testBucket"), inputString).asJson.printWith(noSpaces)
       val input = new ByteArrayInputStream(s3Input.getBytes())


### PR DESCRIPTION
Using checksums to check for zerobytefiles. These files may not be zerobyte but are empty files not wanted in TDR. Maintaining the use of the zeroByteFile puid for these files so rest of app does not need changing and no more 'puids' in disallowed PUIDs
The suggestion was to use a new reason Empty File but as we are already creating a false puid not doing so makes more sense
`INSERT INTO "DisallowedPuids" ("PUID","PUID Description","Reason", "Active")
 ('zeroByteFile', 'Identifier for empty file not in PRONOM', 'ZeroByteFile', false);  `